### PR TITLE
Use NonZeroUsize inside NodeId

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -80,7 +80,7 @@ impl<'a, T: 'a> ExactSizeIterator for Nodes<'a, T> { }
 impl<'a, T: 'a> Iterator for Nodes<'a, T> {
     type Item = NodeRef<'a, T>;
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next().map(|i| unsafe { self.tree.get_unchecked(NodeId(i)) })
+        self.iter.next().map(|i| unsafe { self.tree.get_unchecked(NodeId::from_index(i)) })
     }
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
@@ -88,7 +88,7 @@ impl<'a, T: 'a> Iterator for Nodes<'a, T> {
 }
 impl<'a, T: 'a> DoubleEndedIterator for Nodes<'a, T> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back().map(|i| unsafe { self.tree.get_unchecked(NodeId(i)) })
+        self.iter.next_back().map(|i| unsafe { self.tree.get_unchecked(NodeId::from_index(i)) })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,13 @@ struct Node<T> {
     value: T,
 }
 
+fn _static_assert_size_of_node() {
+    // "Instanciating" the generic `transmute` function without calling it
+    // still triggers the magic compile-time check
+    // that input and output types have the same `size_of()`.
+    let _ = std::mem::transmute::<Node<()>, [usize; 9]>;
+}
+
 impl<T> Node<T> {
     fn new(value: T) -> Self {
         Node {


### PR DESCRIPTION
This allows `Option<NodeId>` to be no larger than `usize`, and saves 32 bytes of memory per node.