### PR TITLE
Fix out-of-bounds access possibility in safe code.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ego-tree"
-version = "0.5.0"
+version = "0.5.1"
 description = "Vec-backed ID-tree"
 keywords = ["tree", "vec", "id", "index"]
 authors = ["Curtis McEnroe <programble@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ego-tree"
-version = "0.5.1"
+version = "0.6.0"
 description = "Vec-backed ID-tree"
 keywords = ["tree", "vec", "id", "index"]
 authors = ["Curtis McEnroe <programble@gmail.com>"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,9 +76,11 @@ impl<T> Node<T> {
 #[derive(Debug)]
 pub struct NodeRef<'a, T: 'a> {
     /// Node ID.
+    #[deprecated(since = "0.5.1", note = "use the id() method instead and upgrade to 0.6")]
     pub id: NodeId,
 
     /// Tree containing the node.
+    #[deprecated(since = "0.5.1", note = "use the tree() method instead and upgrade to 0.6")]
     pub tree: &'a Tree<T>,
 
     node: &'a Node<T>,
@@ -88,9 +90,11 @@ pub struct NodeRef<'a, T: 'a> {
 #[derive(Debug)]
 pub struct NodeMut<'a, T: 'a> {
     /// Node ID.
+    #[deprecated(since = "0.5.1", note = "use the id() method instead and upgrade to 0.6")]
     pub id: NodeId,
 
     /// Tree containing the node.
+    #[deprecated(since = "0.5.1", note = "use the tree() method instead and upgrade to 0.6")]
     pub tree: &'a mut Tree<T>,
 }
 
@@ -103,6 +107,7 @@ impl<'a, T: 'a> Clone for NodeRef<'a, T> {
 
 impl<'a, T: 'a> Eq for NodeRef<'a, T> { }
 impl<'a, T: 'a> PartialEq for NodeRef<'a, T> {
+    #[allow(deprecated)]
     fn eq(&self, other: &Self) -> bool {
         self.id == other.id
             && self.tree as *const _ == other.tree as *const _
@@ -110,6 +115,7 @@ impl<'a, T: 'a> PartialEq for NodeRef<'a, T> {
     }
 }
 
+#[allow(deprecated)]
 impl<T> Tree<T> {
     /// Creates a tree with a root node.
     pub fn new(root: T) -> Self {
@@ -170,7 +176,18 @@ impl<T> Tree<T> {
     }
 }
 
+#[allow(deprecated)]
 impl<'a, T: 'a> NodeRef<'a, T> {
+    /// Returns the ID of this node.
+    pub fn id(&self) -> NodeId {
+        self.id
+    }
+
+    /// Returns the tree owning this node.
+    pub fn tree(&self) -> &'a Tree<T> {
+        self.tree
+    }
+
     /// Returns the value of this node.
     pub fn value(&self) -> &'a T {
         &self.node.value
@@ -212,7 +229,18 @@ impl<'a, T: 'a> NodeRef<'a, T> {
     }
 }
 
+#[allow(deprecated)]
 impl<'a, T: 'a> NodeMut<'a, T> {
+    /// Returns the ID of this node.
+    pub fn id(&self) -> NodeId {
+        self.id
+    }
+
+    /// Returns the tree owning this node.
+    pub fn tree(&mut self) -> &mut Tree<T> {
+        self.tree
+    }
+
     fn node(&mut self) -> &mut Node<T> {
         unsafe { self.tree.node_mut(self.id) }
     }
@@ -520,6 +548,7 @@ impl<'a, T: 'a> NodeMut<'a, T> {
     }
 }
 
+#[allow(deprecated)]
 impl<'a, T: 'a> From<NodeMut<'a, T>> for NodeRef<'a, T> {
     fn from(node: NodeMut<'a, T>) -> Self {
         unsafe { node.tree.get_unchecked(node.id) }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,12 +76,10 @@ impl<T> Node<T> {
 #[derive(Debug)]
 pub struct NodeRef<'a, T: 'a> {
     /// Node ID.
-    #[deprecated(since = "0.5.1", note = "use the id() method instead and upgrade to 0.6")]
-    pub id: NodeId,
+    id: NodeId,
 
     /// Tree containing the node.
-    #[deprecated(since = "0.5.1", note = "use the tree() method instead and upgrade to 0.6")]
-    pub tree: &'a Tree<T>,
+    tree: &'a Tree<T>,
 
     node: &'a Node<T>,
 }
@@ -90,12 +88,10 @@ pub struct NodeRef<'a, T: 'a> {
 #[derive(Debug)]
 pub struct NodeMut<'a, T: 'a> {
     /// Node ID.
-    #[deprecated(since = "0.5.1", note = "use the id() method instead and upgrade to 0.6")]
-    pub id: NodeId,
+    id: NodeId,
 
     /// Tree containing the node.
-    #[deprecated(since = "0.5.1", note = "use the tree() method instead and upgrade to 0.6")]
-    pub tree: &'a mut Tree<T>,
+    tree: &'a mut Tree<T>,
 }
 
 // Trait implementations regardless of T.
@@ -107,7 +103,6 @@ impl<'a, T: 'a> Clone for NodeRef<'a, T> {
 
 impl<'a, T: 'a> Eq for NodeRef<'a, T> { }
 impl<'a, T: 'a> PartialEq for NodeRef<'a, T> {
-    #[allow(deprecated)]
     fn eq(&self, other: &Self) -> bool {
         self.id == other.id
             && self.tree as *const _ == other.tree as *const _
@@ -115,7 +110,6 @@ impl<'a, T: 'a> PartialEq for NodeRef<'a, T> {
     }
 }
 
-#[allow(deprecated)]
 impl<T> Tree<T> {
     /// Creates a tree with a root node.
     pub fn new(root: T) -> Self {
@@ -176,7 +170,6 @@ impl<T> Tree<T> {
     }
 }
 
-#[allow(deprecated)]
 impl<'a, T: 'a> NodeRef<'a, T> {
     /// Returns the ID of this node.
     pub fn id(&self) -> NodeId {
@@ -229,7 +222,6 @@ impl<'a, T: 'a> NodeRef<'a, T> {
     }
 }
 
-#[allow(deprecated)]
 impl<'a, T: 'a> NodeMut<'a, T> {
     /// Returns the ID of this node.
     pub fn id(&self) -> NodeId {
@@ -548,7 +540,6 @@ impl<'a, T: 'a> NodeMut<'a, T> {
     }
 }
 
-#[allow(deprecated)]
 impl<'a, T: 'a> From<NodeMut<'a, T>> for NodeRef<'a, T> {
     fn from(node: NodeMut<'a, T>) -> Self {
         unsafe { node.tree.get_unchecked(node.id) }

--- a/tests/node_mut.rs
+++ b/tests/node_mut.rs
@@ -298,7 +298,7 @@ fn reparent_from_id_append() {
             'e' => { 'f', 'g' },
         }
     };
-    let e_id = tree.root().last_child().unwrap().id;
+    let e_id = tree.root().last_child().unwrap().id();
     tree.root_mut().first_child().unwrap().reparent_from_id_append(e_id);
 
     let b = tree.root().first_child().unwrap();
@@ -322,7 +322,7 @@ fn reparent_from_id_prepend() {
             'e' => { 'c', 'd' },
         }
     };
-    let e_id = tree.root().last_child().unwrap().id;
+    let e_id = tree.root().last_child().unwrap().id();
     tree.root_mut().first_child().unwrap().reparent_from_id_prepend(e_id);
 
     let b = tree.root().first_child().unwrap();

--- a/tests/tree.rs
+++ b/tests/tree.rs
@@ -37,14 +37,14 @@ fn orphan() {
 #[test]
 fn get() {
     let tree = Tree::new('a');
-    let id = tree.root().id;
+    let id = tree.root().id();
     assert_eq!(Some(tree.root()), tree.get(id));
 }
 
 #[test]
 fn get_mut() {
     let mut tree = Tree::new('a');
-    let id = tree.root().id;
+    let id = tree.root().id();
     assert_eq!(Some('a'), tree.get_mut(id).map(|mut n| *n.value()));
 }
 


### PR DESCRIPTION
With the `id` and `tree` fields of `NodeRef` and `NodeMut` being public, it was possible to assign to them. For example, it was possible to build a `NodeMut` for large ID/index in a small tree/Vec. Since some APIs use unchecked indexing, this would let users of this library cause out-of-bounds access in a `Vec` without writing `unsafe` code themselves.

This commit fixes that issue by making the fields private and instead providing read-only access via accessor methods. Now the fields can only be set by the `ego-tree` crate, which can make sure to only ever use an ID that is in-bounds for a given tree.